### PR TITLE
ImportError: No module named ...

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,6 @@ networkx==2.1
 numpy==1.14.3
 psutil==5.4.5
 Werkzeug==0.14.1
+ete3==3.1.1
+numba==0.41.0
+six==1.12.0


### PR DESCRIPTION
`numba` and `ete3` are said missing when running  `python grapetree.py` in python2.7 virtualenv

`numba` `ete3` and `six` are said missing when running  `python grapetree.py` in a python3.6 virtualenv

note that `numpy==1.14.3` could be removed as it is a dependency of `numba`